### PR TITLE
Relax install_requires requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,12 @@ setup(
     download_url='https://github.com/kavgan/word_cloud/archive/{0}.tar.gz'.format(tag()),
     keywords=['word cloud','visualization','text mining'],
     install_requires=[
-        'scikit-learn==0.19.1',
-        'pandas==0.20.3'
+        'scikit-learn>=0.19.1',
+        'pandas>=0.20.3'
     ],
     include_package_data=True,
     entry_points={
 
     }
 )
+


### PR DESCRIPTION
Before making these changes, I wasn't able to have pip successfully install the word_cloud module on my system. Relaxing the requirements for which versions of `pandas` and and `scikit-learn` worked.