### PR TITLE
Make it easier to import WordCloud

### DIFF
--- a/word_cloud/__init__.py
+++ b/word_cloud/__init__.py
@@ -1,0 +1,1 @@
+from .word_cloud_generator import WordCloud


### PR DESCRIPTION
Anything you import into `__init__.py` becomes available at the package level, so now it would be possible to do `from word_cloud import WordCloud`